### PR TITLE
修复几个严重的问题

### DIFF
--- a/dotnetCampus.LatestCSharpFeatures.sln
+++ b/dotnetCampus.LatestCSharpFeatures.sln
@@ -27,10 +27,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetCampus.LatestCSharpFe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetCampus.Nullable.Source", "src\dotnetCampus.Nullable.Source\dotnetCampus.Nullable.Source.csproj", "{72163C73-CBC5-4CB5-BDDF-769B7AFD6FAB}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{19AD69CA-F593-4789-A51F-9E547033147D}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InternalUsageLibrary", "samples\InternalUsageLibrary\InternalUsageLibrary.csproj", "{DF937968-A710-4079-86D2-B2483FF3D81F}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetCampus.LatestCSharpFeatures.Source", "src\dotnetCampus.LatestCSharpFeatures.Source\dotnetCampus.LatestCSharpFeatures.Source.csproj", "{16D75C29-3176-4CFD-A1B5-B5F24876B038}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "IsExternalInit", "IsExternalInit", "{4E06689B-E73A-4A04-AAA0-7959A6EC06E6}"
@@ -43,7 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{CAB44C21-D58
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{878C1D77-0A77-44BD-847E-164188B10677}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dotnetCampus.LatestCSharpFeatures.Tests", "tests\dotnetCampus.LatestCSharpFeatures.Tests\dotnetCampus.LatestCSharpFeatures.Tests.csproj", "{D10BF09A-FDF3-43F0-BD54-49A73554CDAB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetCampus.LatestCSharpFeatures.Tests", "tests\dotnetCampus.LatestCSharpFeatures.Tests\dotnetCampus.LatestCSharpFeatures.Tests.csproj", "{D10BF09A-FDF3-43F0-BD54-49A73554CDAB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "dotnetCampus.LatestCSharpFeatures.Analyzer", "src\dotnetCampus.LatestCSharpFeatures.Analyzer\dotnetCampus.LatestCSharpFeatures.Analyzer.csproj", "{642FA0CA-E827-4D96-9358-D596CD87DAF4}"
 EndProject
@@ -81,10 +77,6 @@ Global
 		{72163C73-CBC5-4CB5-BDDF-769B7AFD6FAB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{72163C73-CBC5-4CB5-BDDF-769B7AFD6FAB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{72163C73-CBC5-4CB5-BDDF-769B7AFD6FAB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DF937968-A710-4079-86D2-B2483FF3D81F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DF937968-A710-4079-86D2-B2483FF3D81F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DF937968-A710-4079-86D2-B2483FF3D81F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DF937968-A710-4079-86D2-B2483FF3D81F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{16D75C29-3176-4CFD-A1B5-B5F24876B038}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{16D75C29-3176-4CFD-A1B5-B5F24876B038}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16D75C29-3176-4CFD-A1B5-B5F24876B038}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -108,7 +100,6 @@ Global
 		{6ED76C7A-A16A-45A5-BC1F-91A880839C31} = {F0CBB519-BB38-4104-B840-4076BB206E36}
 		{4EBF62CB-613E-4496-B890-B1F433ED7581} = {F0CBB519-BB38-4104-B840-4076BB206E36}
 		{72163C73-CBC5-4CB5-BDDF-769B7AFD6FAB} = {CCAAE7A8-1879-4F67-98AA-D837C80227A2}
-		{DF937968-A710-4079-86D2-B2483FF3D81F} = {19AD69CA-F593-4789-A51F-9E547033147D}
 		{4E06689B-E73A-4A04-AAA0-7959A6EC06E6} = {CAB44C21-D58C-4732-B9D8-60B1DAE82BEF}
 		{CCAAE7A8-1879-4F67-98AA-D837C80227A2} = {CAB44C21-D58C-4732-B9D8-60B1DAE82BEF}
 		{F0CBB519-BB38-4104-B840-4076BB206E36} = {CAB44C21-D58C-4732-B9D8-60B1DAE82BEF}

--- a/samples/InternalUsageLibrary/InternalUsageLibrary.csproj
+++ b/samples/InternalUsageLibrary/InternalUsageLibrary.csproj
@@ -1,8 +1,0 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
-  <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netstandard2.0;net48</TargetFrameworks>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-</Project>

--- a/src/dotnetCampus.IsExternalInit.Source/dotnetCampus.IsExternalInit.Source.csproj
+++ b/src/dotnetCampus.IsExternalInit.Source/dotnetCampus.IsExternalInit.Source.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <PackageId>dotnetCampus.IsExternalInit</PackageId>
     <Description>If you use C# 9.0 or later and want to use record types, this '.Source' library adds internal IsExternalInit attribute support to your project. This confines the new language feature to the project itself without affecting other projects that reference it.</Description>

--- a/src/dotnetCampus.IsExternalInit/dotnetCampus.IsExternalInit.csproj
+++ b/src/dotnetCampus.IsExternalInit/dotnetCampus.IsExternalInit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <Description>If you use C# 9.0 or later and want to use record types, this library adds public IsExternalInit attribute support for your project, allowing the new language feature to be propagated to other projects that reference this one.</Description>

--- a/src/dotnetCampus.LatestCSharpFeatures.Source/dotnetCampus.LatestCSharpFeatures.Source.csproj
+++ b/src/dotnetCampus.LatestCSharpFeatures.Source/dotnetCampus.LatestCSharpFeatures.Source.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <Description>This comprehensive package provides support for the latest C# language features in your project, enabling older .NET projects to use newer C# language constructs. Currently includes support for 'nullable', 'init', and 'required' keywords. The types introduced are internal, confining these features to the project itself without affecting other projects that reference it. By installing this package, you get all the newest C# features in one place, eliminating the need to install separate packages for each feature. Future updates will include more new features as they are released.</Description>

--- a/src/dotnetCampus.LatestCSharpFeatures/dotnetCampus.LatestCSharpFeatures.csproj
+++ b/src/dotnetCampus.LatestCSharpFeatures/dotnetCampus.LatestCSharpFeatures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net5.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net7.0;net5.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <Description>This comprehensive package provides support for the latest C# language features in your project, enabling older .NET projects to use newer C# language constructs. Currently includes support for 'nullable', 'init', and 'required' keywords. The types introduced are public, allowing these features to propagate to other projects that reference this one. By installing this package, you get all the newest C# features in one place, eliminating the need to install separate packages for each feature. Future updates will include more new features as they are released.</Description>
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="..\dotnetCampus.Nullable\**\*.cs" Exclude="..\dotnetCampus.Nullable\**\obj\**\*.cs;..\dotnetCampus.Nullable\**\bin\**\*.cs" />
-    <Compile Include="..\dotnetCampus.IsExternalInit\**\*.cs" Exclude="..\dotnetCampus.IsExternalInit\**\obj\**\*.cs;..\dotnetCampus.IsExternalInit\**\bin\**\*.cs" />
-    <Compile Include="..\dotnetCampus.Required\**\*.cs" Exclude="..\dotnetCampus.Required\**\obj\**\*.cs;..\dotnetCampus.Required\**\bin\**\*.cs" />
+    <Compile Include="..\dotnetCampus.Nullable.Source\**\*.cs" Exclude="..\dotnetCampus.Nullable.Source\**\obj\**\*.cs;..\dotnetCampus.Nullable\**\bin\**\*.cs" />
+    <Compile Include="..\dotnetCampus.IsExternalInit.Source\**\*.cs" Exclude="..\dotnetCampus.IsExternalInit.Source\**\obj\**\*.cs;..\dotnetCampus.IsExternalInit\**\bin\**\*.cs" />
+    <Compile Include="..\dotnetCampus.Required.Source\**\*.cs" Exclude="..\dotnetCampus.Required.Source\**\obj\**\*.cs;..\dotnetCampus.Required\**\bin\**\*.cs" />
   </ItemGroup>
 
   <Target Name="IncludeAllDependencies" BeforeTargets="_GetPackageFiles">

--- a/src/dotnetCampus.Nullable.Source/dotnetCampus.Nullable.Source.csproj
+++ b/src/dotnetCampus.Nullable.Source/dotnetCampus.Nullable.Source.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <PackageId>dotnetCampus.Nullable</PackageId>
     <Description>If you use C# 8.0 or later and enable the nullable types, this '.Source' library adds internal nullable reference attributes to your project. This confines the new language feature to the project itself without affecting other projects that reference it.</Description>

--- a/src/dotnetCampus.Nullable/dotnetCampus.Nullable.csproj
+++ b/src/dotnetCampus.Nullable/dotnetCampus.Nullable.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <Description>If you use C# 8.0 or later and enable the nullable types, this library adds public nullable reference attributes to your project, allowing the new language feature to be propagated to other projects that reference this one.</Description>

--- a/src/dotnetCampus.Required.Source/dotnetCampus.Required.Source.csproj
+++ b/src/dotnetCampus.Required.Source/dotnetCampus.Required.Source.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net7.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <PackageId>dotnetCampus.Required</PackageId>
     <Description>For C# 11.0 and newer. This package adds support for the 'required' keyword in your project, enforcing that fields or properties are initialized during object initialization. The types introduced are internal, meaning the 'required' functionality is limited to this project and won't propagate to referencing projects.</Description>

--- a/src/dotnetCampus.Required/dotnetCampus.Required.csproj
+++ b/src/dotnetCampus.Required/dotnetCampus.Required.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net5.0;netcoreapp3.0;netstandard1.0;net40</TargetFrameworks>
+    <TargetFrameworks>net7.0;net5.0;netcoreapp3.0;netstandard2.0;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <RootNamespace>System.Diagnostics.CodeAnalysis</RootNamespace>
     <Description>If you use C# 9.0 or later and want to use record types, this library adds public IsExternalInit attribute support for your project, allowing the new language feature to be propagated to other projects that reference this one.</Description>

--- a/tests/dotnetCampus.LatestCSharpFeatures.Tests/IsExternalInitTest.cs
+++ b/tests/dotnetCampus.LatestCSharpFeatures.Tests/IsExternalInitTest.cs
@@ -2,10 +2,8 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace dotnetCampus.LatestCSharpFeatures.Tests;
 
-[TestClass]
 public class IsExternalInitTest
 {
-    [TestMethod]
     public void CanBeCompiled()
     {
     }

--- a/tests/dotnetCampus.LatestCSharpFeatures.Tests/NullableTest.cs
+++ b/tests/dotnetCampus.LatestCSharpFeatures.Tests/NullableTest.cs
@@ -2,10 +2,8 @@
 
 namespace dotnetCampus.LatestCSharpFeatures.Tests;
 
-[TestClass]
 public class NullableTest
 {
-    [TestMethod]
     public void CanBeCompiled()
     {
         MemberNotNull();

--- a/tests/dotnetCampus.LatestCSharpFeatures.Tests/Properties/Usings.cs
+++ b/tests/dotnetCampus.LatestCSharpFeatures.Tests/Properties/Usings.cs
@@ -1,1 +1,0 @@
-global using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/tests/dotnetCampus.LatestCSharpFeatures.Tests/RequiredTest.cs
+++ b/tests/dotnetCampus.LatestCSharpFeatures.Tests/RequiredTest.cs
@@ -1,9 +1,7 @@
 ﻿namespace dotnetCampus.LatestCSharpFeatures.Tests;
 
-[TestClass]
 public class RequiredTest
 {
-    [TestMethod]
     public void CanBeCompiled()
     {
     }

--- a/tests/dotnetCampus.LatestCSharpFeatures.Tests/dotnetCampus.LatestCSharpFeatures.Tests.csproj
+++ b/tests/dotnetCampus.LatestCSharpFeatures.Tests/dotnetCampus.LatestCSharpFeatures.Tests.csproj
@@ -1,22 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;net48</TargetFrameworks>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFrameworks>net7.0;net6.0;net5.0;netcoreapp3.1;netcoreapp3.0;netstandard2.0;net48;net472;net471;net47;net462;net461;net46;net452;net451;net45;net40</TargetFrameworks>
+    <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\dotnetCampus.LatestCSharpFeatures.Analyzer\dotnetCampus.LatestCSharpFeatures.Analyzer.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+    <PackageReference Include="dotnetCampus.LatestCSharpFeatures.Source" Version="11.0.0-alpha03" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- 修复 netstandard 1.0/1.6 无法使用 C# 新功能的问题（直接去掉对此框架的支持）
- 删除误打包误上传到 nuget.org 的 InternalUsageLibrary 库（已在 nuget.org 上标记了废弃）
- 修复 LatestCSharpFeatures 库编译后没有任何类的问题