### PR TITLE
Adds net47 target framework to support .NET Framework 4.7's built-in ValueTuple support

### DIFF
--- a/src/DotNetCampus.LatestCSharpFeatures/DotNetCampus.LatestCSharpFeatures.csproj
+++ b/src/DotNetCampus.LatestCSharpFeatures/DotNetCampus.LatestCSharpFeatures.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;netstandard2.0;net40</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;net47;net40</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>DotNetCampus.LatestCSharpFeatures</PackageId>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>


### PR DESCRIPTION
这样可以避免 .NET Framework 新版本额外引入依赖。